### PR TITLE
Hide skip button on intro tutorial slides

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,794 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>NimbleMind Game - Updated Tutorial</title>
+<style>
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap');
+    body { font-family:'Inter',sans-serif; margin:0; padding:0; background:#f0f4f8; color:#333; display:flex; align-items:center; justify-content:center; min-height:100vh; user-select:none; }
+    #game-container { width:95%; max-width:640px; background:#fff; border-radius:16px; box-shadow:0 12px 30px rgba(0,0,0,0.08); padding:18px; display:flex; flex-direction:column; align-items:center; }
+    #header { width:100%; display:flex; gap:10px; margin-bottom:12px; }
+    .score-box { background:#e6eef8; padding:8px 14px; border-radius:10px; flex:1; text-align:center; font-weight:700; }
+    .score-box span { display:block; font-size:0.78rem; color:#5b6b7a; font-weight:600; }
+    .score-box .value { font-size:1.4rem; color:#0f1724; margin-top:4px; }
+    #match-counts { display:flex; gap:18px; margin-bottom:12px; width:100%; justify-content:center; }
+    #game-grid { width:100%; display:grid; gap:8px; background:#e9f0f8; padding:10px; border-radius:10px; }
+    .cell { background:#fff; border-radius:10px; display:flex; align-items:center; justify-content:center; font-size:1.25rem; font-weight:800; color:#0f1724; cursor:pointer; aspect-ratio:1/1; box-shadow:0 4px 10px rgba(0,0,0,0.06); transition:transform .18s ease, box-shadow .18s ease; position:relative; user-select:none; -webkit-user-select:none; }
+    .cell:hover { transform:translateY(-3px) scale(1.03); }
+    .empty-cell { background:transparent; box-shadow:none; pointer-events:none; color:transparent; }
+    /* Matched: keep number visible but blurred/faded (NOT removed) */
+    .matched { filter: blur(2px); opacity:0.85; background:#f3f6fa; color:#6b7280; pointer-events:none; box-shadow:inset 0 1px 3px rgba(0,0,0,0.06); }
+    .selected { background:#2563eb; color:white; transform:scale(1.06); box-shadow:0 8px 18px rgba(37,99,235,0.25); }
+    .hint { box-shadow:0 0 0 6px rgba(245,158,11,0.12); animation:hintPulse 1s infinite alternate; }
+    @keyframes hintPulse { from{transform:scale(1)} to{transform:scale(1.03)} }
+    #buttons-container { display:flex; gap:12px; margin-top:12px; align-items:center; }
+    .control-button { background:#2563eb; color:#fff; border:none; border-radius:12px; padding:12px 16px; cursor:pointer; font-weight:700; box-shadow:0 6px 12px rgba(0,0,0,0.08); }
+    .control-button.disabled { opacity:0.5; cursor:not-allowed; box-shadow:none; }
+    #auto-solve-button { background:#16a34a; color:#fff; }
+    #leftover-count { margin-top:10px; font-weight:700; color:#2563eb; }
+    #message-box { position:fixed; top:10%; left:50%; transform:translateX(-50%); background:rgba(12,12,12,0.8); color:white; padding:10px 18px; border-radius:10px; display:none; z-index:4000; }
+    /* Tutorial Overlay */
+    #tutorial-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.7); display:flex; align-items:center; justify-content:center; z-index:5000; }
+    .tutorial-content { background:white; padding:22px; border-radius:14px; max-width:92%; width:560px; text-align:center; color:#111827; }
+    .tutorial-content h2 { margin:0 0 8px 0; font-size:1.6rem; }
+    .tutorial-content p { margin:0 0 10px 0; font-size:1rem; color:#475569; }
+    .tutorial-controls { display:flex; justify-content:space-between; gap:12px; margin-top:12px; }
+    .overlay-button { padding:10px 14px; border-radius:10px; border:none; font-weight:700; cursor:pointer; }
+    .btn-skip { background:#e2e8f0; color:#0f1724; }
+    .btn-start { background:#2563eb; color:white; }
+    .tutorial-step-counter { color:#64748b; font-size:0.9rem; margin-top:6px; }
+    .sparkle { position:absolute; width:10px; height:10px; border-radius:50%; background:white; opacity:0; pointer-events:none; animation:spark 0.5s forwards; }
+    @keyframes spark { from{transform:scale(0); opacity:1} to{transform:scale(1.6); opacity:0} }
+    /* Game over */
+    #game-over-message { display:none; text-align:center; margin-top:14px; }
+    #game-over-message h2 { color:#2563eb; }
+</style>
+</head>
+<body>
+
+<!-- Tutorial overlay -->
+<div id="tutorial-overlay" aria-hidden="false">
+  <div class="tutorial-content" role="dialog" aria-modal="true" aria-labelledby="tutorial-title">
+    <h2 id="tutorial-title">Title</h2>
+    <p id="tutorial-text">Text</p>
+    <div class="tutorial-step-counter" id="tutorial-step">1/4</div>
+    <div class="tutorial-controls">
+      <button class="overlay-button btn-skip" id="overlay-skip">Skip Tutorial</button>
+      <div style="display:flex;gap:8px;">
+        <button class="overlay-button btn-start" id="overlay-prev" style="display:none">Prev</button>
+        <button class="overlay-button btn-start" id="overlay-next">Next</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="game-container" role="main" aria-label="NimbleMind game">
+  <div id="header">
+    <div class="score-box">
+      <span>Score</span>
+      <div class="value" id="score-value">0</div>
+    </div>
+    <div class="score-box">
+      <span>Best</span>
+      <div class="value" id="best-score-value">0</div>
+    </div>
+  </div>
+
+  <div id="match-counts">
+    <div id="pair-matches">Pairs: 0</div>
+    <div id="sum-matches">Sum to 10: 0</div>
+  </div>
+
+  <div id="game-grid" aria-live="polite"></div>
+  <div id="leftover-count"></div>
+
+  <div id="buttons-container">
+    <button id="add-row-button" class="control-button" aria-label="Add row">+ Add Row</button>
+    <button id="hint-button" class="control-button" aria-label="Hint">Hint</button>
+    <button id="auto-solve-button" class="control-button" aria-label="Auto solve">Auto-Solve</button>
+  </div>
+
+  <div id="game-over-message">
+    <h2>Board Cleared!</h2>
+    <button id="restart-button" class="control-button">Restart Game</button>
+  </div>
+</div>
+
+<div id="message-box" role="status" aria-live="assertive"></div>
+
+<script>
+/* ----------------------------
+   Config / Global state
+   ---------------------------- */
+let numColumns = 9;             // dynamic: can be changed for tutorial (3,5,9)
+let totalRows = 9;              // dynamic number of rows for current grid
+let currentRows = 4;            // active rows (for main game start)
+let grid = [];                  // 2D array [row][col]
+let dulledNumbers = {};         // { "r-c": value } to display blurred values after match
+let matchedMap = {};            // { "r-c": true } to note matched display cells
+let selectedCell = null;
+let score = 0;
+let bestScore = localStorage.getItem('nimblemind-best-score') || 0;
+let hintsLeft = 3;
+let addRowClickedCount = 0;
+
+let inTutorial = false;
+let tutorialLevel = 0; // 0 = none, 1 = 3x3, 2 = 5x5
+let tutorialSteps = [
+  { title: "Match Pairs of Numbers", text: "Find pairs of numbers that are the same, or whose sum is 10, and tap them." },
+  { title: "Check Different Directions", text: "Pairs can be matched horizontally, vertically, or diagonally. They can also be separated by matched or empty cells." },
+  { title: "Use the Add Row Button", text: "If there are no more pairs, tap the '+' button to add a new row of numbers to the bottom of the grid." },
+  { title: "Clear the Board!", text: "Your goal is to match all the numbers on the board." }
+];
+let currentTutorialStep = 0;
+
+/* UI references */
+const gameGridElement = document.getElementById('game-grid');
+const scoreValueElement = document.getElementById('score-value');
+const bestScoreValueElement = document.getElementById('best-score-value');
+const pairMatchesElement = document.getElementById('pair-matches');
+const sumMatchesElement = document.getElementById('sum-matches');
+const addRowButton = document.getElementById('add-row-button');
+const hintButton = document.getElementById('hint-button');
+const autoSolveButton = document.getElementById('auto-solve-button');
+const messageBox = document.getElementById('message-box');
+const restartButton = document.getElementById('restart-button');
+const leftoverCountElement = document.getElementById('leftover-count');
+
+const tutorialOverlay = document.getElementById('tutorial-overlay');
+const tutorialTitle = document.getElementById('tutorial-title');
+const tutorialText = document.getElementById('tutorial-text');
+const tutorialStepCounter = document.getElementById('tutorial-step');
+const overlayNext = document.getElementById('overlay-next');
+const overlayPrev = document.getElementById('overlay-prev');
+const overlaySkip = document.getElementById('overlay-skip');
+
+bestScoreValueElement.textContent = bestScore;
+
+/* ----------------------------
+   Utility / Logging
+   ---------------------------- */
+function log(...args){ console.log('[nimblemind]', ...args); }
+
+/* ----------------------------
+   Grid helpers
+   ---------------------------- */
+function makeEmptyGrid(rows, cols) {
+  const g = [];
+  for (let r=0; r<rows; r++){
+    g[r] = [];
+    for (let c=0; c<cols; c++){
+      g[r][c] = null;
+    }
+  }
+  return g;
+}
+
+/* ----------------------------
+   Tutorial loaders
+   ---------------------------- */
+function startTutorialSequence() {
+  inTutorial = true;
+  currentTutorialStep = 0;
+  tutorialLevel = 0;
+  showTutorialStep();
+}
+
+function showTutorialStep() {
+  const step = tutorialSteps[currentTutorialStep];
+  tutorialTitle.textContent = step.title;
+  tutorialText.textContent = step.text;
+  tutorialStepCounter.textContent = `${currentTutorialStep+1}/${tutorialSteps.length}`;
+  overlayPrev.style.display = currentTutorialStep === 0 ? 'none' : 'inline-block';
+  overlayNext.textContent = (currentTutorialStep === tutorialSteps.length - 1) ? 'Start Tutorial' : 'Next';
+  
+  // Hide Skip Tutorial button during the first 4 intro slides (steps 0-3)
+  // Only show it on the final step when user can choose to start tutorial levels
+  overlaySkip.style.display = (currentTutorialStep === tutorialSteps.length - 1) ? 'inline-block' : 'none';
+  
+  tutorialOverlay.style.display = 'flex';
+}
+
+/* Called when user chooses to start the tutorial levels */
+function startTutorialLevels() {
+  tutorialOverlay.style.display = 'none';
+  inTutorial = true;
+  tutorialLevel = 1;
+  loadTutorialLevel(1);
+}
+
+/* Skip tutorial -> launch main game */
+function skipTutorial() {
+  tutorialOverlay.style.display = 'none';
+  inTutorial = false;
+  tutorialLevel = 0;
+  // restore main game dimensions
+  numColumns = 9;
+  totalRows = 9;
+  startGame();
+}
+
+/* Load specific tutorial level grids */
+function loadTutorialLevel(level) {
+  log('Loading tutorial level', level);
+  if (level === 1) {
+    // 3x3 tutorial: 8 * 55 + 1 * 24
+    numColumns = 3;
+    totalRows = 3;
+    currentRows = 3;
+    grid = [
+      [55,55,55],
+      [55,24,55],
+      [55,55,55]
+    ];
+    dulledNumbers = {};
+    matchedMap = {};
+    selectedCell = null;
+    score = 0;
+    updateScoreDisplay();
+    renderGrid();
+    showMessage('Level 1: Tap horizontal or vertical adjacent 55 pairs (24 is not matchable).');
+  } else if (level === 2) {
+    // 5x5 tutorial: 24 * 55 + 1 * 24
+    numColumns = 5;
+    totalRows = 5;
+    currentRows = 5;
+    grid = [
+      [55,55,55,55,55],
+      [55,55,55,55,55],
+      [55,55,55,24,55],
+      [55,55,55,55,55],
+      [55,55,55,55,55]
+    ];
+    dulledNumbers = {};
+    matchedMap = {};
+    selectedCell = null;
+    score = 0;
+    updateScoreDisplay();
+    renderGrid();
+    showMessage('Level 2: Tap diagonal adjacent 55 pairs to learn diagonal matching.');
+  } else {
+    // fallback -> finish tutorial
+    inTutorial = false;
+    tutorialLevel = 0;
+    numColumns = 9;
+    totalRows = 9;
+    startGame();
+  }
+}
+
+/* proceed to next tutorial level after completion */
+function advanceTutorialLevel() {
+  if (!inTutorial) return;
+  if (tutorialLevel === 1) {
+    tutorialLevel = 2;
+    loadTutorialLevel(2);
+  } else if (tutorialLevel === 2) {
+    // finish and load main game
+    inTutorial = false;
+    tutorialLevel = 0;
+    numColumns = 9;
+    totalRows = 9;
+    startGame();
+  }
+}
+
+/* ----------------------------
+   Grid rendering & UI
+   ---------------------------- */
+function renderGrid() {
+  gameGridElement.innerHTML = '';
+  // set columns dynamic
+  gameGridElement.style.gridTemplateColumns = `repeat(${numColumns}, 1fr)`;
+
+  // ensure grid has dimension totalRows x numColumns
+  // if grid is smaller, expand with nulls
+  for (let r=0; r<totalRows; r++){
+    if (!grid[r]) grid[r] = [];
+    for (let c=0; c<numColumns; c++){
+      if (grid[r][c] === undefined) grid[r][c] = null;
+      const cell = document.createElement('div');
+      cell.className = 'cell';
+      cell.dataset.rowIndex = r;
+      cell.dataset.colIndex = c;
+
+      // if cell is matched (present in matchedMap) display dulled number (kept visible)
+      const key = `${r}-${c}`;
+      if (matchedMap[key]) {
+        // show dulled number but style as matched
+        cell.classList.add('matched');
+        cell.textContent = dulledNumbers[key] !== undefined ? dulledNumbers[key] : (grid[r][c] !== null ? grid[r][c] : '');
+      } else {
+        // active cell content (could be null or number)
+        if (grid[r][c] !== null) {
+          cell.textContent = grid[r][c];
+        } else {
+          // empty slot
+          cell.classList.add('empty-cell');
+          cell.textContent = '';
+        }
+      }
+
+      // only attach click handler to non-empty active numbers
+      cell.addEventListener('click', handleCellClick);
+      gameGridElement.appendChild(cell);
+    }
+  }
+  updateMatchCounts();
+  updateLeftoverCount();
+}
+
+/* mark cell matched visually but DO NOT remove visible number permanently
+   for game logic, matched cells should be treated as "cleared" (i.e., not active)
+   so we keep grid[r][c] as null (so logic treats it as empty), but store value in dulledNumbers & matchedMap for rendering
+*/
+function markCellAsMatched(rowIndex, colIndex) {
+  const key = `${rowIndex}-${colIndex}`;
+  // store the value for display
+  dulledNumbers[key] = (grid[rowIndex] && grid[rowIndex][colIndex] !== null) ? grid[rowIndex][colIndex] : (dulledNumbers[key] || null);
+  // mark map for rendering as matched
+  matchedMap[key] = true;
+  // set grid cell to null so game logic treats it as cleared (but we keep the dulledNumbers map for UI)
+  if (grid[rowIndex]) grid[rowIndex][colIndex] = null;
+
+  // update DOM element class if present
+  const cell = gameGridElement.querySelector(`[data-row-index="${rowIndex}"][data-col-index="${colIndex}"]`);
+  if (cell) {
+    cell.classList.add('matched');
+    cell.classList.remove('selected');
+    createSparkle(cell);
+  }
+}
+
+/* ----------------------------
+   Matching / Rules
+   ---------------------------- */
+
+/* Checks if all rows between two given rows are clear (null)
+   Accepts current dynamic numColumns / totalRows
+*/
+function checkClearRowsBetween(r1, c1, r2, c2) {
+  const startRow = Math.min(r1, r2) + 1;
+  const endRow = Math.max(r1, r2) - 1;
+  if (endRow < startRow) return true;
+  for (let r=startRow; r<=endRow; r++){
+    for (let c=0; c<numColumns; c++){
+      if (grid[r] && grid[r][c] !== null) return false;
+    }
+  }
+  return true;
+}
+
+/* Next-line path checking (keeps original logic) */
+function checkNumberInNextLine(r1, c1, r2, c2) {
+  if (Math.abs(r1 - r2) !== 1) return false;
+  // path from c1 to end of row r1
+  let pathClear1 = true;
+  for (let c = c1 + 1; c < numColumns; c++){
+    if (grid[r1][c] !== null) { pathClear1 = false; break; }
+  }
+  if (!pathClear1) return false;
+  // path from c2 to start of row r2
+  let pathClear2 = true;
+  for (let c = c2 - 1; c >= 0; c--){
+    if (grid[r2][c] !== null) { pathClear2 = false; break; }
+  }
+  return pathClear2;
+}
+
+/* Main isValidMatch — unchanged semantics but uses dynamic numColumns/totalRows
+   Accepts two coordinates and returns true if they are valid according to game rules:
+   - identical values OR sum to 10
+   - direct adjacency (including diagonal)
+   - horizontal/vertical/diagonal with only nulls between
+   - next-line path & multi-row clear path rules
+*/
+function isValidMatch(r1, c1, r2, c2, testGrid = grid) {
+  // basic bounds
+  if (r1 < 0 || r2 < 0 || c1 < 0 || c2 < 0) return false;
+  if (r1 >= totalRows || r2 >= totalRows || c1 >= numColumns || c2 >= numColumns) return false;
+
+  const val1 = testGrid[r1][c1];
+  const val2 = testGrid[r2][c2];
+  if (val1 === null || val2 === null) return false;
+  if (!((val1 === val2) || (val1 + val2 === 10))) return false;
+
+  // direct adjacency (including diagonal)
+  if (Math.abs(r1 - r2) <= 1 && Math.abs(c1 - c2) <= 1) return true;
+
+  // horizontal path (same row) with only nulls between
+  if (r1 === r2) {
+    const start = Math.min(c1, c2) + 1;
+    const end = Math.max(c1, c2);
+    let clearPath = true;
+    for (let c = start; c < end; c++) {
+      if (testGrid[r1][c] !== null) { clearPath = false; break; }
+    }
+    if (clearPath) return true;
+  }
+
+  // vertical path (same col) with only nulls between
+  if (c1 === c2) {
+    const start = Math.min(r1, r2) + 1;
+    const end = Math.max(r1, r2);
+    let clearPath = true;
+    for (let r = start; r < end; r++) {
+      if (testGrid[r][c1] !== null) { clearPath = false; break; }
+    }
+    if (clearPath) return true;
+  }
+
+  // diagonal path: equal row/col distance with nulls between
+  if (Math.abs(r1 - r2) === Math.abs(c1 - c2)) {
+    const rDir = (r2 > r1) ? 1 : -1;
+    const cDir = (c2 > c1) ? 1 : -1;
+    let r = r1 + rDir;
+    let c = c1 + cDir;
+    let clearPath = true;
+    while (r !== r2 && c !== c2) {
+      if (testGrid[r][c] !== null) { clearPath = false; break; }
+      r += rDir; c += cDir;
+    }
+    if (clearPath) return true;
+  }
+
+  // next-line path using cleared rows
+  if (r1 !== r2 && checkClearRowsBetween(r1,c1,r2,c2)) {
+    if (checkNumberInNextLine(r1,c1,r2,c2)) return true;
+  }
+
+  return false;
+}
+
+/* ----------------------------
+   Input handling
+   ---------------------------- */
+function handleCellClick(e) {
+  const cell = e.currentTarget;
+  const r = parseInt(cell.dataset.rowIndex, 10);
+  const c = parseInt(cell.dataset.colIndex, 10);
+  const key = `${r}-${c}`;
+
+  // ignore clicks on already matched/empty cells
+  if (matchedMap[key] || grid[r][c] === null) return;
+
+  // if no selection yet
+  if (!selectedCell) {
+    selectedCell = cell;
+    selectedCell.classList.add('selected');
+    return;
+  }
+
+  // if clicked same cell -> deselect
+  if (selectedCell === cell) {
+    selectedCell.classList.remove('selected');
+    selectedCell = null;
+    return;
+  }
+
+  // get previous selected coordinates
+  const pr = parseInt(selectedCell.dataset.rowIndex, 10);
+  const pc = parseInt(selectedCell.dataset.colIndex, 10);
+
+  // check match
+  if (isValidMatch(pr, pc, r, c)) {
+    // record dulled numbers & mark matched (visual)
+    markCellAsMatched(pr, pc);
+    markCellAsMatched(r, c);
+    updateScore(1);
+    if (selectedCell) selectedCell.classList.remove('selected');
+    selectedCell = null;
+
+    // If tutorial mode: if certain count or all matched trigger next level
+    if (inTutorial) {
+      // Quick rule: advance level when N matches have been made or no more possible matches
+      const matches = findPossibleMatches();
+      // count matchedMap keys for this tutorial grid
+      const matchedCount = Object.keys(matchedMap).length / 2; // pairs
+      // level thresholds: level1 -> 3 matches; level2 -> 4 matches (arbitrary demo)
+      if ((tutorialLevel === 1 && matchedCount >= 3) || (tutorialLevel === 2 && matchedCount >= 4) || matches.length === 0) {
+        setTimeout(() => {
+          showMessage('Tutorial level complete!');
+          setTimeout(advanceTutorialLevel, 700);
+        }, 350);
+      }
+    } else {
+      checkGameStatus();
+    }
+  } else {
+    // invalid match -> select new cell (UX choice): show shake and set new selection
+    if (selectedCell) selectedCell.classList.remove('selected');
+    selectedCell = cell;
+    selectedCell.classList.add('selected');
+    // brief shake effect
+    cell.animate([{ transform: 'translateX(-6px)' }, { transform: 'translateX(6px)' }, { transform: 'translateX(0)' }], { duration: 250 });
+    showMessage('Not a valid match');
+  }
+}
+
+/* ----------------------------
+   Find possible matches / hints / autosolve
+   ---------------------------- */
+function findPossibleMatches() {
+  const unmatched = [];
+  for (let r=0; r<totalRows; r++){
+    for (let c=0; c<numColumns; c++){
+      if (grid[r] && grid[r][c] !== null) unmatched.push({r,c,val:grid[r][c]});
+    }
+  }
+  const pairs = [];
+  for (let i=0; i<unmatched.length; i++){
+    for (let j=i+1; j<unmatched.length; j++){
+      const a = unmatched[i], b = unmatched[j];
+      if (isValidMatch(a.r, a.c, b.r, b.c)) pairs.push([a,b]);
+    }
+  }
+  return pairs;
+}
+
+function giveHint() {
+  if (hintsLeft <= 0) { showMessage('No hints left'); return; }
+  const matches = findPossibleMatches();
+  if (!matches.length) { showMessage('No matches available'); return; }
+  const p = matches[0];
+  const el1 = gameGridElement.querySelector(`[data-row-index="${p[0].r}"][data-col-index="${p[0].c}"]`);
+  const el2 = gameGridElement.querySelector(`[data-row-index="${p[1].r}"][data-col-index="${p[1].c}"]`);
+  if (el1 && el2) {
+    el1.classList.add('hint'); el2.classList.add('hint');
+    setTimeout(()=>{ el1.classList.remove('hint'); el2.classList.remove('hint'); }, 1400);
+    hintsLeft--; updateHintButton();
+  }
+}
+
+function autoSolve() {
+  const matches = findPossibleMatches();
+  if (!matches.length) { showMessage('No pairs found for the bot'); return; }
+  const p = matches[0];
+  const el1 = gameGridElement.querySelector(`[data-row-index="${p[0].r}"][data-col-index="${p[0].c}"]`);
+  const el2 = gameGridElement.querySelector(`[data-row-index="${p[1].r}"][data-col-index="${p[1].c}"]`);
+  if (el1 && el2) {
+    el1.click();
+    setTimeout(()=>el2.click(), 380);
+  }
+}
+
+/* ----------------------------
+   Add row / grid generation
+   ---------------------------- */
+function generateInitialGrid() {
+  // standard main-game start: use dynamic numColumns x currentRows arrangement
+  // We'll create pairs and complements so initial grid is solvable
+  log('generateInitialGrid', numColumns, currentRows);
+  grid = makeEmptyGrid(totalRows, numColumns);
+  dulledNumbers = {};
+  matchedMap = {};
+
+  const activeCells = currentRows * numColumns;
+  const numbers = [];
+  for (let i=0;i<activeCells/2;i++){
+    const n = Math.floor(Math.random()*9) + 1;
+    if (Math.random() > 0.5) numbers.push(n,n);
+    else {
+      const comp = 10 - n;
+      if (comp > 0 && comp < 10) numbers.push(n,comp);
+      else numbers.push(n,n);
+    }
+  }
+  // shuffle
+  for (let i=numbers.length-1;i>0;i--){ const j = Math.floor(Math.random()*(i+1)); [numbers[i],numbers[j]] = [numbers[j],numbers[i]]; }
+  let idx = 0;
+  for (let r=0;r<totalRows;r++){
+    for (let c=0;c<numColumns;c++){
+      if (r < currentRows) {
+        grid[r][c] = numbers[idx++];
+
+      } else {
+        grid[r][c] = null;
+      }
+    }
+  }
+}
+
+/* add a new row at bottom with intelligent options */
+function addRow() {
+  if (currentRows >= totalRows) { showMessage('Grid is full'); return; }
+  addRowClickedCount++;
+  const newRow = new Array(numColumns).fill(null);
+  // gather unmatched values
+  const unmatched = [];
+  for (let r=0;r<currentRows; r++){
+    for (let c=0;c<numColumns; c++){
+      if (grid[r][c] !== null) unmatched.push(grid[r][c]);
+    }
+  }
+  // fill row depending on click count (as before)
+  if (addRowClickedCount === 1) {
+    for (let i=0;i<numColumns && i<unmatched.length;i++) newRow[i] = unmatched[i];
+  } else if (addRowClickedCount === 2) {
+    for (let i=0;i<numColumns && i<unmatched.length;i++) {
+      const num = unmatched[i];
+      const comp = 10 - num;
+      newRow[i] = (comp > 0 && comp < 10 && Math.random()>0.4) ? comp : num;
+    }
+  } else {
+    // strategic pairs + random fill
+    const pairsToCreate = Math.min(Math.ceil(Math.random()*2), Math.floor(unmatched.length/2));
+    for (let i=0;i<pairsToCreate;i++){
+      const num = unmatched[Math.floor(Math.random()*unmatched.length)];
+      let pos;
+      do { pos = Math.floor(Math.random()*numColumns); } while (newRow[pos] !== null);
+      if (Math.random() > 0.5) newRow[pos] = num; else {
+        const comp = 10 - num;
+        newRow[pos] = (comp > 0 && comp < 10) ? comp : num;
+      }
+    }
+    for (let i=0;i<numColumns;i++) if (newRow[i] === null) newRow[i] = Math.floor(Math.random()*9)+1;
+  }
+
+  // put newRow into grid at index currentRows (0-based)
+  if (!grid[currentRows]) grid[currentRows] = new Array(numColumns).fill(null);
+  grid[currentRows] = newRow.slice();
+  currentRows++;
+  renderGrid();
+  checkGameStatus();
+}
+
+/* ----------------------------
+   UI updates & helpers
+   ---------------------------- */
+function updateMatchCounts() {
+  const matches = findPossibleMatches();
+  let pairCount = 0, sumCount = 0;
+  matches.forEach(p => {
+    const a = p[0], b = p[1];
+    if (a.val === b.val) pairCount++;
+    else if (a.val + b.val === 10) sumCount++;
+  });
+  pairMatchesElement.textContent = `Pairs: ${pairCount}`;
+  sumMatchesElement.textContent = `Sum to 10: ${sumCount}`;
+}
+
+function updateLeftoverCount() {
+  let cnt = 0;
+  for (let r=0;r<currentRows;r++){
+    for (let c=0;c<numColumns;c++){
+      if (grid[r][c] !== null) cnt++;
+    }
+  }
+  leftoverCountElement.textContent = `Numbers to pair: ${cnt}`;
+}
+
+function updateScoreDisplay() {
+  scoreValueElement.textContent = score;
+  bestScoreValueElement.textContent = bestScore;
+}
+
+function updateHintButton(){
+  hintButton.textContent = `Hint (${hintsLeft})`;
+  if (hintsLeft <= 0) hintButton.classList.add('disabled'); else hintButton.classList.remove('disabled');
+}
+
+function showMessage(text, timeout=1400){
+  messageBox.textContent = text;
+  messageBox.style.display = 'block';
+  setTimeout(()=>{ messageBox.style.display = 'none'; }, timeout);
+}
+
+/* sparkle effect */
+function createSparkle(cell) {
+  const s = document.createElement('div'); s.className = 'sparkle';
+  const size = Math.random()*12 + 6;
+  s.style.width = `${size}px`; s.style.height = `${size}px`;
+  const x = Math.random() * (cell.offsetWidth - size);
+  const y = Math.random() * (cell.offsetHeight - size);
+  s.style.left = `${x}px`; s.style.top = `${y}px`;
+  cell.appendChild(s);
+  setTimeout(()=>s.remove(), 520);
+}
+
+/* ----------------------------
+   Game flow: start / restart / status
+   ---------------------------- */
+function updateScore(points){
+  score += points;
+  if (score > bestScore) { bestScore = score; localStorage.setItem('nimblemind-best-score', bestScore); }
+  updateScoreDisplay();
+}
+
+function checkGameStatus(){
+  const allMatched = grid.every((row, r) => row.every((cell, c) => cell === null));
+  const matches = findPossibleMatches();
+  if (allMatched) {
+    showMessage('Board cleared! Starting new game', 1800);
+    setTimeout(startGame, 1200);
+    return;
+  }
+  if (matches.length === 0) {
+    // allow add-row
+    addRowButton.classList.remove('disabled');
+    showMessage('No more pairs — add a row to continue');
+  } else {
+    addRowButton.classList.add('disabled');
+  }
+}
+
+/* Start main game flow */
+function startGame() {
+  inTutorial = false;
+  tutorialLevel = 0;
+  // main-game expects 9 columns & 9 total rows and currentRows=4 initial
+  numColumns = 9;
+  totalRows = 9;
+  currentRows = 4;
+  addRowClickedCount = 0;
+  score = 0;
+  hintsLeft = 3;
+  selectedCell = null;
+  matchedMap = {};
+  dulledNumbers = {};
+  updateScoreDisplay();
+  updateHintButton();
+  generateInitialGrid();
+  renderGrid();
+  checkGameStatus();
+}
+
+/* ----------------------------
+   Event listeners
+   ---------------------------- */
+overlayNext.addEventListener('click', ()=> {
+  if (currentTutorialStep < tutorialSteps.length - 1) {
+    currentTutorialStep++;
+    showTutorialStep();
+  } else {
+    // final -> start tutorial levels
+    startTutorialLevels();
+  }
+});
+overlayPrev.addEventListener('click', ()=> {
+  if (currentTutorialStep > 0) { currentTutorialStep--; showTutorialStep(); }
+});
+overlaySkip.addEventListener('click', ()=> {
+  skipTutorial();
+});
+
+addRowButton.addEventListener('click', ()=> {
+  if (addRowButton.classList.contains('disabled')) return;
+  addRow();
+});
+hintButton.addEventListener('click', ()=> {
+  if (hintButton.classList.contains('disabled')) return;
+  giveHint();
+});
+autoSolveButton.addEventListener('click', ()=> autoSolve());
+restartButton.addEventListener('click', ()=> startGame());
+
+/* On load: show tutorial overlay and run */
+window.addEventListener('load', ()=> {
+  // show tutorial slides first
+  currentTutorialStep = 0;
+  tutorialOverlay.style.display = 'flex';
+  showTutorialStep();
+});
+
+/* small unit test runner (keeps your original debug tests)
+   For clarity these are logged to console -- optional
+*/
+function runTests() {
+  log('Running quick isValidMatch smoke tests...');
+  // simple test grid to exercise direct adjacency and diagonal
+  const tg = [
+    [5,5,null],
+    [null,5,5],
+    [5,null,5]
+  ];
+  log('adjacent horizontal (0,0)-(0,1):', isValidMatch(0,0,0,1, tg));
+  log('diagonal (0,0)-(1,1):', isValidMatch(0,0,1,1,tg));
+  log('non-adj blocked (0,0)-(2,0):', isValidMatch(0,0,2,0,tg));
+}
+runTests();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
Hide the "Skip Tutorial" button during the initial tutorial intro slides to ensure users view all introductory content.

The task specifically requested that the "Skip Tutorial" button only be visible on the final intro slide, allowing users to navigate through the initial explanation slides without the option to skip them. This ensures a more structured introduction to the game mechanics.

---
<a href="https://cursor.com/background-agent?bcId=bc-7195b0fb-5467-49b9-9466-228e16e1ab7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7195b0fb-5467-49b9-9466-228e16e1ab7d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

