### PR TITLE
Remove tutorial features from 3x3 grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,12 +250,34 @@ class InteractiveTutorial {
   showTutorial() {
     if (this.tutorialContainer) {
       this.tutorialContainer.style.display = 'block';
+      
+      // Hide main game features during interactive tutorial
+      const header = document.getElementById('header');
+      const matchCounts = document.getElementById('match-counts');
+      const buttonsContainer = document.getElementById('buttons-container');
+      const leftoverCount = document.getElementById('leftover-count');
+      
+      if (header) header.style.display = 'none';
+      if (matchCounts) matchCounts.style.display = 'none';
+      if (buttonsContainer) buttonsContainer.style.display = 'none';
+      if (leftoverCount) leftoverCount.style.display = 'none';
     }
   }
   
   hideTutorial() {
     if (this.tutorialContainer) {
       this.tutorialContainer.style.display = 'none';
+      
+      // Show main game features again when tutorial is hidden
+      const header = document.getElementById('header');
+      const matchCounts = document.getElementById('match-counts');
+      const buttonsContainer = document.getElementById('buttons-container');
+      const leftoverCount = document.getElementById('leftover-count');
+      
+      if (header) header.style.display = 'flex';
+      if (matchCounts) matchCounts.style.display = 'flex';
+      if (buttonsContainer) buttonsContainer.style.display = 'flex';
+      if (leftoverCount) leftoverCount.style.display = 'block';
     }
   }
   
@@ -376,6 +398,9 @@ class InteractiveTutorial {
     
     // Reset instructions
     this.instructions.textContent = 'Click "Start Tutorial" to begin. Follow the highlighted pairs in order!';
+    
+    // Hide tutorial and restore main game features
+    this.hideTutorial();
   }
 }
 


### PR DESCRIPTION
Hide main game UI elements during the interactive tutorial to provide a focused learning experience.

The user requested to "remove" Score, Best, Add row hint, and auto solve from the interactive tutorial. These elements are part of the main game UI, not the tutorial itself. This PR hides them when the tutorial is active to prevent distractions and ensure users focus solely on the tutorial grid.

---
<a href="https://cursor.com/background-agent?bcId=bc-3525c757-3bc3-4050-be97-526c351c8461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3525c757-3bc3-4050-be97-526c351c8461">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

